### PR TITLE
Fixed #9 Added option to disable the Nagle's algorithm

### DIFF
--- a/websocket-sharp-core/Server/WebSocketServer.cs
+++ b/websocket-sharp-core/Server/WebSocketServer.cs
@@ -69,6 +69,7 @@ namespace WebSocketSharp.Server
     private Logger                             _logger;
     private int                                _port;
     private string                             _realm;
+    private bool                               _noDelay;
     private Thread                             _receiveThread;
     private bool                               _reuseAddress;
     private bool                               _secure;
@@ -387,6 +388,15 @@ namespace WebSocketSharp.Server
         return _logger;
       }
     }
+    
+    /// <summary>
+    /// Nagle's algorithm. Disable the delay when send or receive buffers are not full. If true, disable the delay. Default is false.
+    /// </summary>
+    public bool NoDelay
+    {
+      get { return _noDelay; }
+      set { _noDelay = value; }
+    }
 
     /// <summary>
     /// Gets the port on which to listen for incoming connection requests.
@@ -616,6 +626,7 @@ namespace WebSocketSharp.Server
       while (true) {
         try {
           var cl = await _listener.AcceptTcpClientAsync();
+          cl.NoDelay = _noDelay;
           ThreadPool.QueueUserWorkItem (
             state => {
               try {

--- a/websocket-sharp-core/WebSocket.cs
+++ b/websocket-sharp-core/WebSocket.cs
@@ -110,6 +110,7 @@ namespace WebSocketSharp
         private ClientSslConfiguration _sslConfig;
         private Stream _stream;
         private TcpClient _tcpClient;
+        private bool _noDelay;
         private Uri _uri;
         private const string _version = "13";
         private TimeSpan _waitTime;
@@ -447,6 +448,15 @@ namespace WebSocketSharp
             get { return _logger; }
 
             internal set { _logger = value; }
+        }
+
+        /// <summary>
+        /// Nagle's algorithm. Disable the delay when send or receive buffers are not full. If true, disable the delay. Default is false.
+        /// </summary>
+        public bool NoDelay
+        {
+            get { return _noDelay; }
+            set { _noDelay = value; }
         }
 
         /// <summary>
@@ -1760,6 +1770,7 @@ namespace WebSocketSharp
                     {
                         releaseClientResources();
                         _tcpClient = new TcpClient();
+                        _tcpClient.NoDelay = _noDelay;
                         await _tcpClient.ConnectAsync(_proxyUri.DnsSafeHost, _proxyUri.Port);
                         _stream = _tcpClient.GetStream();
                     }
@@ -1784,6 +1795,7 @@ namespace WebSocketSharp
             if (_proxyUri != null)
             {
                 _tcpClient = new TcpClient();
+                _tcpClient.NoDelay = _noDelay;
                 _tcpClient.ConnectAsync(_proxyUri.DnsSafeHost, _proxyUri.Port).WaitForResult();
                 _stream = _tcpClient.GetStream();
                 sendProxyConnectRequest();
@@ -1791,6 +1803,7 @@ namespace WebSocketSharp
             else
             {
                 _tcpClient = new TcpClient();
+                _tcpClient.NoDelay = _noDelay;
                 _tcpClient.ConnectAsync(_uri.DnsSafeHost, _uri.Port).WaitForResult();
                 _stream = _tcpClient.GetStream();
             }


### PR DESCRIPTION
In Linux TCP socket used NoDelay = false by default. This means that socket will wait until send buffer filled to send it's content. As result short messages will delivered much later from moment they putted to buffer.

